### PR TITLE
Improve Username page design

### DIFF
--- a/pages/me/settings/username.js
+++ b/pages/me/settings/username.js
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import Head from 'next/head';
+import Image from 'next/image';
+import projectLumiere from "@public/images/logos/ProjectLumiere.svg";
 
 export default function Username() {
   const [username, setUsername] = useState('');
@@ -30,20 +32,31 @@ export default function Username() {
   return (
     <>
       <Head>
-        <title>Editor | Lumiere</title>
+        <title>Welcome | Lumiere</title>
       </Head>
-      <div className='h-screen grid place-items-center'>
+      <div className='h-screen grid place-items-center text-center'>
         <main>
-          <h1>Set your username</h1>
-          <form onSubmit={submitUsername}>
+          <object className='flex justify-center'>
+            <Image
+                src={projectLumiere}
+                alt='Project Lumiere logo'
+                height={100}
+                width={100}
+            />
+          </object>
+          <h1 className='mt-2 heading-primary text-white'>Welcome to Lumiere!</h1>
+          <p className='mt-2 mb-5'>Let&#39;s get started. Set your username below and you&#39;re all set to go.</p>
+          <form onSubmit={submitUsername} className='space-x-2'>
             <span>@</span>
             <input
               type='text'
               autoFocus
               onChange={(e) => setUsername(e.target.value)}
               value={username}
+              placeholder='Username'
+              className={`py-3 lg:py-2.5 rounded-lg border-2 bg-transparent pr-9 lg:pr-8 pl-4 text-sm border-gray-700 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-600 hover:border-gray-600 placeholder-gray-500`}
             />
-            <input type='submit' value='Submit username' disabled={!username} />
+            <input type='submit' value='Submit username' className='px-5 py-3 lg:py-2.5 button-tertiary bg-transparent cursor-pointer' />
           </form>
           <p>{error}</p>
         </main>


### PR DESCRIPTION
Hey!

This pull request improves the design of the username page — the page the user is first introduced to after creating an account on Lumiere. The initial design was still probably bare bones, so I added some styles to them!

Have a look at the before and after below.

| Before | After |
|:------:|:-----:|
![Screenshot 2021-10-12 at 08-44-28 Editor Lumiere](https://user-images.githubusercontent.com/47273556/136872315-2e507036-9ced-4835-bf08-e9c7376c182f.png) | ![Screenshot 2021-10-12 at 08-43-05 Welcome Lumiere](https://user-images.githubusercontent.com/47273556/136872342-31fc3aa6-9d37-424b-b12c-308911e76d80.png) |

What do you think? Anything that can be better?