### PR TITLE
Improve Press page design

### DIFF
--- a/pages/press/index.js
+++ b/pages/press/index.js
@@ -11,7 +11,8 @@ export default function Press({ publications }) {
       </Head>
 
       <main className='container'>
-        <h1>Public Publications</h1>
+        <h1 className='heading-primary mb-5'>Lumiere Press</h1>
+        <section className='flex flex-col space-y-5'>
         {publications.map((publication) => (
           <Publication
             key={publication.id}
@@ -19,6 +20,7 @@ export default function Press({ publications }) {
             visibility='public'
           />
         ))}
+        </section>
       </main>
     </>
   );


### PR DESCRIPTION
This pull requests wraps the publications in a `section` that adds vertical spacing between each publication. That way, they won't be touching each other and will look better with consistent spacing between them!

Additionally, "Public Publications" has been changed to "Lumiere Press" to be more consistent with the links that point to it.

| Before | After |
|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/47273556/137425636-bf454cdf-6a84-4ad1-be57-38291d4c2893.png) | ![image](https://user-images.githubusercontent.com/47273556/137425670-41932131-e95d-4348-962c-0864df670b05.png) |

Let me know what you think! :)
